### PR TITLE
Refactor and minor changes

### DIFF
--- a/Messages/2.1.0.txt
+++ b/Messages/2.1.0.txt
@@ -1,0 +1,18 @@
+The Nunjucks package has been successfully updated to version 2.1.0
+
+Fixes:
+ - resolve highlighting issue inside HTML tags with attributes
+
+Features:
+ - add PHP support
+
+Refactor:
+ - moved context definitions into separate named blocks: `nunjucks-statement`,
+   `nunjucks-expression`, and `nunjucks-comment`
+ - added a new `prototype` context to include `nunjucks` package globally
+ - simplified the `main` context with a single reference to `meta.template.njk`
+ - updated statement, expression, and comment blocks to use individual includes for
+   relevant Nunjucks elements
+
+Please report issues here: https://github.com/alsolovyev/Nunjucks/issues
+Created by janeRivas <solovyev.a@icloud.com>

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ _* to update the package `Package Control: Upgrade Package` select `Nunjucks`_
 ### Syntaxes
 
 - [Nunjucks](https://github.com/alsolovyev/Nunjucks/blob/master/Syntaxes/Nunjucks.sublime-syntax) - HTML basic
+- [Nunjucks PHP](https://github.com/alsolovyev/Nunjucks/blob/master/Syntaxes/Nunjucks%20PHP.sublime-syntax) - with PHP syntax support
 
 ### Filters
 

--- a/Syntaxes/Nunjucks PHP.sublime-syntax
+++ b/Syntaxes/Nunjucks PHP.sublime-syntax
@@ -1,0 +1,28 @@
+%YAML 1.2
+---
+name: Nunjucks PHP
+version: 2
+scope: text.html.njk
+extends: Packages/HTML/HTML.sublime-syntax
+
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: Nunjucks.sublime-syntax#nunjucks
+    - include: php-block
+
+  main:
+    - meta_prepend: true
+    - meta_scope: meta.template.njk
+
+  # PHP
+  php-block:
+  - match: <\?(?:php|=)
+    scope: punctuation.section.embedded.begin.php
+    push:
+      - meta_scope: source.php.embedded
+      - match: \?>
+        scope: punctuation.section.embedded.end.php
+        pop: true
+      - include: scope:source.php

--- a/Syntaxes/Nunjucks.sublime-syntax
+++ b/Syntaxes/Nunjucks.sublime-syntax
@@ -40,10 +40,25 @@ variables:
 
 
 contexts:
+  prototype:
+    - meta_prepend: true
+    - include: nunjucks
+
   main:
     - meta_prepend: true
+    - meta_scope: meta.template.njk
+
+  # Nunjucks Includes
+  nunjucks:
+    - include: nunjucks-statement
+    - include: nunjucks-expression
+    - include: nunjucks-comment
+
+  ## Base
+  nunjucks-statement:
     - match: '\{%-?'
       scope: punctuation.statement.begin.njk
+      pop: true
       push:
         - meta_scope: meta.statement.njk
         - match: '-?%\}'
@@ -59,9 +74,10 @@ contexts:
         - include: nunjucks-macros
         - include: nunjucks-variables
 
-    # Expression Block
+  nunjucks-expression:
     - match: '\{\{-?'
       scope: punctuation.expression.begin.njk
+      pop: true
       push:
         - meta_scope: meta.expression.njk
         - match: '-?\}\}'
@@ -77,17 +93,16 @@ contexts:
         - include: nunjucks-macros
         - include: nunjucks-variables
 
-    # Comment Block
+  nunjucks-comment:
     - match: '{#-?'
       scope: punctuation.definition.comment.begin.njk
+      pop: true
       push:
         - meta_scope: comment.block.njk
         - match: '-?#}'
           scope: punctuation.definition.comment.end.njk
           pop: true
 
-
-  # Nunjucks Includes
   ## Punctuation
   nunjucks-punctuation:
     - include: nunjucks-dots

--- a/messages.json
+++ b/messages.json
@@ -1,5 +1,6 @@
 {
   "install": "Messages/install.txt",
   "2.0.1": "Messages/2.0.1.txt",
-  "2.0.3": "Messages/2.0.3.txt"
+  "2.0.3": "Messages/2.0.3.txt",
+  "2.1.0": "Messages/2.1.0.txt"
 }


### PR DESCRIPTION
- add PHP support
- fix highlight inside HTML tags
- move context definitions into separate named blocks: `nunjucks-statement`, `nunjucks-expression`, and `nunjucks-comment`
- add a new `prototype` context to include `nunjucks` package globally
- simplify the `main` context with a single reference to `meta.template.njk`
- update statement, expression, and comment blocks to use individual includes for relevant Nunjucks elements